### PR TITLE
add box add command + support for multiple outputs per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ func main() {
 
 ## Available Actions
 
+### BoxAdd
+Adds a box to your local vagrant box collection. Takes a location which is the 
+name, url, or path of the box
+
+```go
+func (*VagrantClient) BoxAdd(location string) *BoxAddCommand
+```
+
+Response:
+* **Error** - Set if an error occurred.
+
+
 ### BoxList
 Return a list of available vagrant boxes.
 

--- a/command_box_add.go
+++ b/command_box_add.go
@@ -1,0 +1,98 @@
+package vagrant
+
+import "errors"
+
+type CheckSumType string
+
+const (
+	MD5    CheckSumType = "md5"
+	SHA1   CheckSumType = "sha1"
+	SHA256 CheckSumType = "sha256"
+)
+
+// A BoxAddCommand specifies the options and output of vagrant box add.
+type BoxAddCommand struct {
+	BaseCommand
+	ErrorResponse
+
+	// Clean any temporary download files. This will prevent resuming a previously started download.
+	Clean bool
+
+	// Overwrite an existing box if it exists
+	Force bool
+
+	// Name, url, or path of the box.
+	Location string
+
+	// Name of the box. Only has to be set if the box is provided as a path or url without metadata.
+	Name string
+
+	// Checksum for the box
+	Checksum string
+
+	// Type of the supplied Checksum. Allowed values are vagrant.MD5, vagrant.SHA1, vagrant.SHA256
+	CheckSumType CheckSumType
+}
+
+// BoxAdd adds a vagrant box to your local boxes.
+// Its parameter location is the name, url, or path of the box. After setting
+// options as appropriate, you must call Run() or Start() followed by Wait()
+// to execute. Errors will be recorded in Error.
+func (client *VagrantClient) BoxAdd(location string) *BoxAddCommand {
+	return &BoxAddCommand{
+		Location:      location,
+		BaseCommand:   newBaseCommand(client),
+		ErrorResponse: newErrorResponse(),
+	}
+}
+
+func (cmd *BoxAddCommand) buildArguments() ([]string, error) {
+	args := []string{"add"}
+	if cmd.Clean {
+		args = append(args, "-c")
+	}
+	if cmd.Force {
+		args = append(args, "-f")
+	}
+	if cmd.Name != "" {
+		args = append(args, "--name", cmd.Name)
+	}
+	if cmd.Checksum != "" {
+		args = append(args, "--checksum", cmd.Checksum)
+	}
+	if cmd.CheckSumType != "" {
+		if cmd.Checksum == "" {
+			return nil, errors.New("box add: no checksum set even though checksum type was set")
+		}
+		args = append(args, "--checksum-type", string(cmd.CheckSumType))
+	}
+	if cmd.Location == "" {
+		return nil, errors.New("box add: location must be provided")
+	}
+	args = append(args, cmd.Location)
+	return args, nil
+}
+
+func (cmd *BoxAddCommand) init() error {
+	args, err := cmd.buildArguments()
+	if err != nil {
+		return err
+	}
+	return cmd.BaseCommand.init(&cmd.ErrorResponse, "box", args...)
+}
+
+// Run the command
+func (cmd *BoxAddCommand) Run() error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+// Start the command. You must call Wait() to complete execution.
+func (cmd *BoxAddCommand) Start() error {
+	if err := cmd.init(); err != nil {
+		return err
+	}
+	return cmd.BaseCommand.Start()
+}

--- a/command_box_add_test.go
+++ b/command_box_add_test.go
@@ -1,0 +1,101 @@
+package vagrant
+
+import "testing"
+
+func init() {
+	successfulOutput["box add"] = `
+1631018118,box,ui,output,==> box: Loading metadata for box 'ubuntu/trusty64'
+1631018118,box,ui,detail,    box: URL: https://vagrantcloud.com/ubuntu/trusty64
+1631018119,box,ui,output,==> box: Adding box 'ubuntu/trusty64' (v20190514.0.0) for provider: virtualbox
+1631018119,box,ui,detail,    box: Downloading: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/20190514.0.0/providers/virtualbox.box
+1631018119,,ui,detail,Progress: 0% (Rate: 0*/s%!(VAGRANT_COMMA) Estimated time remaining: --:--:--)
+1631018120,,ui,detail,Progress: 100% (Rate: 215/s%!(VAGRANT_COMMA) Estimated time remaining: --:--:--)
+1631018121,,ui,detail,Download redirected to host: cloud-images.ubuntu.com
+1631018121,,ui,detail,Progress: 100% (Rate: 121/s%!(VAGRANT_COMMA) Estimated time remaining: --:--:--)
+1631018121,,ui,detail,Progress: 0% (Rate: 0*/s%!(VAGRANT_COMMA) Estimated time remaining: --:--:--)
+1631018123,,ui,detail,Progress: 1% (Rate: 6429k/s%!(VAGRANT_COMMA) Estimated time remaining: 0:03:05)
+1631018124,,ui,detail,Progress: 8% (Rate: 17.4M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:42)
+1631018125,,ui,detail,Progress: 15% (Rate: 21.2M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:27)
+1631018126,,ui,detail,Progress: 21% (Rate: 23.5M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:21)
+1631018127,,ui,detail,Progress: 28% (Rate: 24.7M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:17)
+1631018128,,ui,detail,Progress: 35% (Rate: 29.2M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:14)
+1631018129,,ui,detail,Progress: 42% (Rate: 29.2M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:12)
+1631018130,,ui,detail,Progress: 49% (Rate: 29.6M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:10)
+1631018131,,ui,detail,Progress: 56% (Rate: 29.3M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:09)
+1631018132,,ui,detail,Progress: 63% (Rate: 29.5M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:07)
+1631018133,,ui,detail,Progress: 67% (Rate: 27.6M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:06)
+1631018134,,ui,detail,Progress: 74% (Rate: 27.4M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:05)
+1631018135,,ui,detail,Progress: 81% (Rate: 27.4M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:04)
+1631018136,,ui,detail,Progress: 88% (Rate: 27.2M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:02)
+1631018137,,ui,detail,Progress: 94% (Rate: 27.1M/s%!(VAGRANT_COMMA) Estimated time remaining: 0:00:01)
+1631018138,box,ui,success,==> box: Successfully added box 'ubuntu/trusty64' (v20190514.0.0) for 'virtualbox'!
+`
+}
+func TestBoxAddCommand_buildArguments(t *testing.T) {
+	client := newMockVagrantClient()
+
+	t.Run("error-on-missing-location", func(t *testing.T) {
+		cmd := client.BoxAdd("")
+		_, err := cmd.buildArguments()
+		assertErr(t, err)
+	})
+	t.Run("default", func(t *testing.T) {
+		cmd := client.BoxAdd("ubuntu/trusty64")
+		args, err := cmd.buildArguments()
+		assertNoErr(t, err)
+		assertArguments(t, args, "add", "ubuntu/trusty64")
+	})
+	t.Run("checksum-type", func(t *testing.T) {
+		cmd := client.BoxAdd("ubuntu/trusty64")
+		cmd.Checksum = "test"
+		cmd.CheckSumType = SHA1
+		args, err := cmd.buildArguments()
+		assertNoErr(t, err)
+		assertArguments(t, args, "add", "--checksum", "test", "--checksum-type", "sha1", "ubuntu/trusty64")
+	})
+	t.Run("checksum", func(t *testing.T) {
+		cmd := client.BoxAdd("ubuntu/trusty64")
+		cmd.Checksum = "test"
+		args, err := cmd.buildArguments()
+		assertNoErr(t, err)
+		assertArguments(t, args, "add", "--checksum", "test", "ubuntu/trusty64")
+	})
+	t.Run("error-on-checksum-type-without-checksum", func(t *testing.T) {
+		cmd := client.BoxAdd("ubuntu/trusty64")
+		cmd.CheckSumType = SHA1
+		_, err := cmd.buildArguments()
+		assertErr(t, err)
+	})
+	t.Run("name", func(t *testing.T) {
+		cmd := client.BoxAdd("ubuntu/trusty64")
+		cmd.Name = "myubuntu"
+		args, err := cmd.buildArguments()
+		assertNoErr(t, err)
+		assertArguments(t, args, "add", "--name", "myubuntu", "ubuntu/trusty64")
+	})
+	t.Run("force", func(t *testing.T) {
+		cmd := client.BoxAdd("ubuntu/trusty64")
+		cmd.Force = true
+		args, err := cmd.buildArguments()
+		assertNoErr(t, err)
+		assertArguments(t, args, "add", "-f", "ubuntu/trusty64")
+	})
+	t.Run("clean", func(t *testing.T) {
+		cmd := client.BoxAdd("ubuntu/trusty64")
+		cmd.Clean = true
+		args, err := cmd.buildArguments()
+		assertNoErr(t, err)
+		assertArguments(t, args, "add", "-c", "ubuntu/trusty64")
+	})
+}
+func TestBoxAddCommand_Run(t *testing.T) {
+	client := newMockVagrantClient()
+	cmd := client.BoxAdd("ubuntu/trusty64")
+	cmd.Env = newEnvTestOutputKey("box add")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Command failed to run: %v", err)
+	}
+	if cmd.Error != nil {
+		t.Fatalf("Command returned error: %v", cmd.Error)
+	}
+}

--- a/command_box_list_test.go
+++ b/command_box_list_test.go
@@ -1,9 +1,11 @@
 package vagrant
 
-import "testing"
+import (
+	"testing"
+)
 
 func init() {
-	successfulOutput["box"] = `
+	successfulOutput["box list"] = `
 1630581222,,ui,info,andreiborisov/macos-bigsur-intel (parallels%!(VAGRANT_COMMA) 1.3.0)
 1630581222,,box-name,andreiborisov/macos-bigsur-intel
 1630581222,,box-provider,parallels
@@ -17,6 +19,7 @@ func init() {
 func TestBoxListCommand_Run(t *testing.T) {
 	client := newMockVagrantClient()
 	cmd := client.BoxList()
+	cmd.Env = newEnvTestOutputKey("box list")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Command failed to run: %v", err)
 	}

--- a/vagrant_client_test.go
+++ b/vagrant_client_test.go
@@ -18,6 +18,18 @@ func newMockVagrantClient() *VagrantClient {
 	}
 }
 
+func assertErr(t *testing.T, err error) {
+	if err == nil {
+		t.Fail()
+	}
+}
+
+func assertNoErr(t *testing.T, err error) {
+	if err != nil {
+		t.Fail()
+	}
+}
+
 func assertArguments(t *testing.T, args []string, expected ...string) {
 	if len(args) != len(expected) {
 		t.Fatalf("Expected %v args; got %v", len(expected), len(args))


### PR DESCRIPTION
First commit enables testing for commands like `box` that have multiple subcommands like `box list` and `box add` by setting the output key via the command environment 